### PR TITLE
fix - for publish to pub.dev, remove ios frameworks and android aar files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,9 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation(name: 'trustwalletcore', ext: 'aar')
+
+    // https://github.com/trustwallet/wallet-core
+    // https://mvnrepository.com/artifact/com.trustwallet/wallet-core
+    // implementation(name: 'trustwalletcore', ext: 'aar')
+    implementation group: 'com.trustwallet', name: 'wallet-core', version: '2.6.3' // use this, has running errors
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/flutter_trust_wallet_core.podspec
+++ b/ios/flutter_trust_wallet_core.podspec
@@ -15,12 +15,15 @@ A Flutter plugin for trust wallet core
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '12.0'  # fix for install errors
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
 
   # trust wallet core
-  s.vendored_frameworks = 'Frameworks/*.xcframework'
+  # s.vendored_frameworks = 'Frameworks/*.xcframework'
+  s.dependency 'TrustWalletCore'
+  s.dependency 'SwiftProtobuf'
+
 end


### PR DESCRIPTION

## update: 

- After removing the iOS dependency on `Frameworks/*.xcframework`, the package size will be <50MB(Android aar file = 10 MB), then it should be able to publish to pub.dev.  😄


### iOS: 

- replace `Frameworks/*.xcframework` by pod
- I've verified the example on my iPhone, and it works fine.

### Android: 

- https://mvnrepository.com/artifact/com.trustwallet/wallet-core/2.6.3
- after i use `implementation group: 'com.trustwallet', name: 'wallet-core', version: '2.6.3'`  replace `implementation(name: 'trustwalletcore', ext: 'aar')`, the example  compiles fine, but runs with some errors, here: 
- https://github.com/weishirongzhen/flutter_trust_wallet_core/issues/12


