### PR TITLE
[Android] Fetching TrustWalletCore binary from official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A Flutter plugin for trust wallet core, Can access all api list in [https://github.com/trustwallet/wallet-core/tree/master/include/TrustWalletCore](https://github.com/trustwallet/wallet-core/tree/master/include/TrustWalletCore)
 
 # Android
+
+minSdk require >=23
+
 Add 
 ```
 class MainActivity: FlutterActivity() {
@@ -11,16 +14,22 @@ class MainActivity: FlutterActivity() {
     }
 }
  ```
-in your android project MainActivity.ky file
+in your android project MainActivity.kt file
 
-minSdk require >=23
+## Create github authoken
+
+Create [github auth token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to fetch binary from official TrustWalletCore maven repo
+
+Set gradle project property gpr.user and gpr.token or set system environment variable GH_USERNAME and GH_TOKEN with the credentials you recieved from github
+
 
 # iOS
 
 min ios platform support >=13.0
 
 
-# dart part
+# Flutter 
+
 before use wallet_core, call below function once.
 ```
  FlutterTrustWalletCore.init();

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,12 +18,13 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url = uri("https://maven.pkg.github.com/weishirongzhen/wallet-core")
-            credentials {
-                username = "weishirongzhen"
-                password = "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" // GH token for only allow read package
-            }
+        maven {  
+            url = uri("https://maven.pkg.github.com/weishirongzhen/wallet-core")             
+            credentials {                 
+                username = project.findProperty("gpr.user") as String ?: System.getenv("GH_USERNAME")                 
+                password = project.findProperty("gpr.token") as String ?: System.getenv("GH_TOKEN")                 
+                // create your token -> https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token             
+             }         
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,13 +17,12 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {  
-            url = uri("https://maven.pkg.github.com/weishirongzhen/wallet-core")             
+            url = uri("https://maven.pkg.github.com/trustwallet/wallet-core")             
             credentials {                 
                 username = project.findProperty("gpr.user") as String ?: System.getenv("GH_USERNAME")                 
-                password = project.findProperty("gpr.token") as String ?: System.getenv("GH_TOKEN")                 
-                // create your token -> https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token             
+                password = project.findProperty("gpr.token") as String ?: System.getenv("GH_TOKEN")                             
              }         
         }
     }
@@ -45,5 +44,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.weishirongzhen:wallet-core:2.6.20"
+    implementation "com.trustwallet:wallet-core:2.7.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,8 @@ rootProject.allprojects {
         maven {  
             url = uri("https://maven.pkg.github.com/trustwallet/wallet-core")             
             credentials {                 
-                username = project.findProperty("gpr.user") as String ?: System.getenv("GH_USERNAME")                 
-                password = project.findProperty("gpr.token") as String ?: System.getenv("GH_TOKEN")                             
+                username = project.findProperty("gpr.user") ?: System.getenv("GH_USERNAME")                 
+                password = project.findProperty("gpr.token") ?: System.getenv("GH_TOKEN")                             
              }         
         }
     }


### PR DESCRIPTION
# Description

It is now possible to fetch binary directly from TrustWalletCore repository (refer to #38)

# Type of change

This is a breaking change as developers now need to generate their github credentials and add them to their flutter project (see Readme). Otherwise binary can not be fetched.